### PR TITLE
[ADD]category 별 제품조회 엔드포인트 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,13 @@ const morgan = require('morgan')
 const dotenv = require('dotenv')
 dotenv.config();
 const app = express()
+
+const routers = require('./routers');
+
 app.use(cors())
 app.use(morgan(':method :url :status :res[content-length] - :response-time ms'));
 app.use(express.json());
+app.use(routers);
 
 app.get('/ping', function(req, res){
     res.json({message: 'pong'})

--- a/controllers/categoriesController.js
+++ b/controllers/categoriesController.js
@@ -1,0 +1,41 @@
+const categoriesService = require('../services/categoriesService');
+
+const erroHandler = (err, res) => {
+    return res.status(err.statusCode || 500).json({ message: err.message });
+}
+
+const categories = async (req, res) => {
+    const { categoriesId } = req.params;
+
+    if (Number(categoriesId) === 1) {
+        return await type(req, res)
+    } else if (Number(categoriesId) === 2) {
+        return await color(req, res)
+    }
+}
+
+const type = async (req, res) => {
+    try {
+        const { typeId } = req.params;
+
+        const products = await categoriesService.typeSearch(typeId);
+        return res.status(200).json({ products: products });
+    } catch (err) {
+        erroHandler(err, res);
+    }
+}
+
+const color = async (req, res) => {
+    try {
+        const { typeId } = req.params;
+        
+        const products = await categoriesService.colorsSearch(typeId);
+        return res.status(200).json({ products: products });
+    } catch (err) {
+        erroHandler(err, res);
+    }
+}
+
+module.exports = {
+    categories
+}

--- a/controllers/categoriesController.js
+++ b/controllers/categoriesController.js
@@ -4,7 +4,7 @@ const errorHandler = (err, res) => {
     return res.status(err.statusCode || 500).json({ message: err.message });
 }
 
-const categoriesType = async (req, res) => {
+const getCategoryListByType = async (req, res) => {
     try {
         const { typeId } = req.params;
         const products = await categoriesService.searchByType(typeId);
@@ -14,7 +14,7 @@ const categoriesType = async (req, res) => {
     }
 }
 
-const categoriesColor = async (req, res) => {
+const getCategoryListByColor = async (req, res) => {
     try {
         const { colorId } = req.params;
         const products = await categoriesService.searchByColor(colorId);
@@ -25,6 +25,6 @@ const categoriesColor = async (req, res) => {
 }
 
 module.exports = {
-    categoriesType,
-    categoriesColor
+    getCategoryListByType,
+    getCategoryListByColor
 }

--- a/models/categoriesDao.js
+++ b/models/categoriesDao.js
@@ -1,0 +1,70 @@
+const { database } = require('./database');
+
+const searchProductsType = async (typeId) => {
+    try {
+        const result = await database.query(`
+        SELECT
+            products.id AS productid,
+            products.name,
+            products.price,
+            products.description,
+            products.type_id,
+            products.thumbnail_url,
+            JSON_OBJECTAGG(color.id, color_name) AS color,
+            JSON_OBJECTAGG(size.id, size.size) AS size
+        FROM products
+        LEFT JOIN sizes_products ON products.id = sizes_products.product_id
+        INNER JOIN size ON sizes_products.size_id = size.id
+        INNER JOIN colors_products ON products.id = colors_products.product_id
+        INNER JOIN color ON colors_products.color_id = color.id
+        WHERE products.type_id = ?
+        GROUP BY products.id`
+        , [typeId]);
+        return JSON.parse(JSON.stringify(result));
+    } catch (err) {
+        const error = new Error('INVALID_DATA_INPUT');
+        error.statusCode = 500;
+        throw error;
+    }
+}
+
+const searchProductsColor = async (colorId) => {
+    try {
+        const result = await database.query(`
+        SELECT
+            products.id AS productid,
+            products.name,
+            products.price,
+            products.description,
+            products.type_id,
+                (SELECT 
+                    pi.image_url 
+                FROM product_image pi 
+                INNER join products p
+                ON pi.product_id = p.id
+                INNER JOIN color c 
+                ON pi.color_id = c.id
+                WHERE pi.product_id = products.id
+                AND pi.color_id = color.id) AS image_ulr,
+            JSON_OBJECTAGG(color.id, color_name) AS color,
+            JSON_OBJECTAGG(size.id, size.size) AS size
+        FROM products
+        LEFT JOIN sizes_products ON products.id = sizes_products.product_id
+        INNER JOIN size ON sizes_products.size_id = size.id
+        INNER JOIN colors_products ON products.id = colors_products.product_id
+        INNER JOIN color ON colors_products.color_id = color.id
+        WHERE color.id = ?
+        GROUP BY products.id`
+        , [colorId]);
+        return JSON.parse(JSON.stringify(result));
+    } catch (err) {
+        const error = new Error('INVALID_DATA_INPUT');
+        error.statusCode = 500;
+        throw error;
+    }
+}
+
+module.exports = {
+    searchProductsType,
+    searchProductsColor
+}

--- a/routers/categoriesRouter.js
+++ b/routers/categoriesRouter.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const categoriesController = require('../controllers/categoriesController');
+const router = express.Router();
+
+router.get('/:categoriesId/:typeId', categoriesController.categories);
+
+module.exports = {
+    router
+}

--- a/routers/index.js
+++ b/routers/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const categoriesRouter = require('./categoriesRouter');
+
+router.use('/categories', categoriesRouter.router);
+
+module.exports = router;

--- a/routes/categoriesRouter.js
+++ b/routes/categoriesRouter.js
@@ -2,8 +2,8 @@ const express = require('express');
 const categoriesController = require('../controllers/categoriesController');
 const router = express.Router();
 
-router.get('/type/:typeId', categoriesController.categoriesType)
-router.get('/color/:colorId', categoriesController.categoriesColor)
+router.get('/type/:typeId', categoriesController.getCategoryListByType);
+router.get('/color/:colorId', categoriesController.getCategoryListByColor);
 
 module.exports = {
     router

--- a/services/categoriesService.js
+++ b/services/categoriesService.js
@@ -9,8 +9,8 @@ const convertJson = (datas) => {
     return datas
 }
 
-const searchByType = async (categoryName) => {
-    const productInfos = await categoriesDao.getProductByType(categoryName);
+const searchByType = async (typeId) => {
+    const productInfos = await categoriesDao.getProductByType(typeId);
     return await convertJson(productInfos);
 }
 

--- a/services/categoriesService.js
+++ b/services/categoriesService.js
@@ -1,0 +1,25 @@
+const categoriesDao = require('../models/categoriesDao');
+
+const convertJson = (datas) => {
+    for(const data of datas) {
+        data.color = JSON.parse(data.color);
+        data.size = JSON.parse(data.size);
+    }
+    return datas
+}
+
+const typeSearch = async (categoryName) => {
+    const productInfos = await categoriesDao.searchProductsType(categoryName);
+    return await convertJson(productInfos);
+}
+
+const colorsSearch = async (colorId) => {
+    const productInfos = await categoriesDao.searchProductsColor(colorId)
+    return await convertJson(productInfos);
+}
+
+
+module.exports = {
+    typeSearch,
+    colorsSearch
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카테고리(제품종류, 색상)에 따른 해당 제품 조회 기능 엔드포인트 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 제품종류 및 색상에 따른 해당 제품 조회
- postman을 통하여 서버 정상작동 여부를 확인
- 카테고리 별 id 값을 통하여 제품타입 별 조회 및 제품 색깔별 조회 기능 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 데이터테이블 간의 복잡한 관계와 프론트에서 요청하는 데이터 형식에 맞는 값으로 데이터를 추출하기 위한
   쿼리문 작성에 어려움이 있었습니다.
- 쿼리문으로 데이터를 받는 과정에서 JSON_OBJECTAGG를 통해 color와 size의 데이터를 조회하여, 해당 JSON형식을 javascript로
- 반복문을 통한 JSON.parse해야하는 문제가 발생하였습니다.
- 색깔별로 제품을 조회할 때 해당 제품이 보유한 다른 색깔에 대한 정보를 담아오지 못하는 문제점이 발생하였습니다.

<br />

## :: 기타 질문 및 특이 사항
- 쿼리문이 길어서 가독성에 어려움이 있는 것 같습니다. 조금 더 효율적인 방법이 없는지 고민이 필요할 것 같습니다.
